### PR TITLE
Switch to ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 COPY gcp-artifact-registry-docker-proxy /
-CMD ["/gcp-artifact-registry-docker-proxy"]
+ENTRYPOINT ["/gcp-artifact-registry-docker-proxy"]


### PR DESCRIPTION
This enables running the container and passing arguments without needing to the know the install path in the image which is useless because it's the only file in the image.