### PR TITLE
Migrate from deprecated metadata.ProjectID to context-aware method

### DIFF
--- a/cmd/gcp-artifact-registry-docker-proxy/main.go
+++ b/cmd/gcp-artifact-registry-docker-proxy/main.go
@@ -58,7 +58,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		id, _ := metadata.ProjectID()
+		id, _ := metadata.ProjectIDWithContext(context.Background())
 
 		gcpCredentials = &auth.Credentials{
 			ProjectID:   id,


### PR DESCRIPTION
Fixes CI error from #21